### PR TITLE
FRESH-215 Procurement WebUI language not updated when changed in bpartner

### DIFF
--- a/src/main/java/de/metas/procurement/webui/sync/SyncBPartnerImportService.java
+++ b/src/main/java/de/metas/procurement/webui/sync/SyncBPartnerImportService.java
@@ -19,12 +19,12 @@ import de.metas.procurement.webui.repository.BPartnerRepository;
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 2 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-2.0.html>.
@@ -50,10 +50,6 @@ public class SyncBPartnerImportService extends AbstractSyncImportService
 		//
 		// Import the BPartner only
 		final BPartner bpartner = importBPartnerNoCascade(syncBpartner);
-		if (bpartner == null)
-		{
-			return null;
-		}
 
 		//
 		// Users
@@ -72,7 +68,7 @@ public class SyncBPartnerImportService extends AbstractSyncImportService
 				logger.warn("Failed importing contracts for {}. Skipped", bpartner, ex);
 			}
 		}
-		
+
 		return bpartner;
 	}
 
@@ -94,7 +90,7 @@ public class SyncBPartnerImportService extends AbstractSyncImportService
 			{
 				deleteBPartner(bpartner);
 			}
-			return null;
+			return bpartner;
 		}
 
 		if (bpartner == null)


### PR DESCRIPTION
fix: if a bpartnerSync with Delete=true comes in, then all existing
users are "deleted"